### PR TITLE
Update builddeb.sh

### DIFF
--- a/builddeb.sh
+++ b/builddeb.sh
@@ -27,7 +27,7 @@ DIRNAME=${PWD##*/}
 VERSION=""
 TARNAME=""
 TEMPDIR=""
-DEBDATE="$(date +'%a, %d %b %Y %H:%M:%S %z')"
+DEBDATE="$(date -R)"
 MISSINGPKG=""
 DISTO=$(lsb_release -is)
 DISTROVERSION=$(lsb_release -rs)
@@ -225,7 +225,7 @@ fi
 #  4a.  Update the packaging changelog
 #########################################################################################
   cd $TEMPDIR/motion
-  echo "motion ($VERSION-1) $DISTRONAME; urgency=medium\n\n  * See changelog in source\n\n -- $DEBUSERNAME <$DEBUSEREMAIL>  $DEBDATE\n" >./debian/changelog
+  printf "motion ($VERSION-1) $DISTRONAME; urgency=medium\n\n  * See changelog in source\n\n -- $DEBUSERNAME <$DEBUSEREMAIL>  $DEBDATE\n" >./debian/changelog
 
 #########################################################################################
 #  6.  Call the packager application (dpkg-buildpackage) output result to a buildlog file.


### PR DESCRIPTION
Debian's helper scripts need date in debian/changelog to be compliant to RFC-2822. Together with that, using printf instead of echo for writing into the changelog keeps consistent formatting whether /bin/sh is linked to dash (mostly standard nowadays) or bash.

Had problems using the script caused by the false date format (using de_DE.UTF-8) and not building the deb.
Now it should be locale and shell independent.