### PR TITLE
Do not try to create existing home directory

### DIFF
--- a/debian01/motion.postinst
+++ b/debian01/motion.postinst
@@ -16,6 +16,7 @@ add_user_if_missing() {
     if ! id -u motion > /dev/null 2>&1; then
         mkdir -m 02750 -p /var/lib/motion
         adduser --system --home /var/lib/motion \
+          --no-create-home \
           --disabled-password \
           --force-badname motion \
           --ingroup motion

--- a/debian02/motion.postinst
+++ b/debian02/motion.postinst
@@ -16,6 +16,7 @@ add_user_if_missing() {
     if ! id -u motion > /dev/null 2>&1; then
         mkdir -m 02750 -p /var/lib/motion
         adduser --system --home /var/lib/motion \
+          --no-create-home \
           --disabled-password \
           --force-badname motion \
           --ingroup motion

--- a/debian03/motion.postinst
+++ b/debian03/motion.postinst
@@ -16,6 +16,7 @@ add_user_if_missing() {
     if ! id -u motion > /dev/null 2>&1; then
         mkdir -m 02750 -p /var/lib/motion
         adduser --system --home /var/lib/motion \
+          --no-create-home \
           --disabled-password \
           --force-badname motion \
           --ingroup motion

--- a/debian04/motion.postinst
+++ b/debian04/motion.postinst
@@ -16,6 +16,7 @@ add_user_if_missing() {
     if ! id -u motion > /dev/null 2>&1; then
         mkdir -m 02750 -p /var/lib/motion
         adduser --system --home /var/lib/motion \
+          --no-create-home \
           --disabled-password \
           --force-badname motion \
           --ingroup motion


### PR DESCRIPTION
Redo of #14 as of split packaging for different distro versions.

`adduser` prints a warning if `--home` is used with an existing directory and `--no-create-home` is not passed. Since this directory is explicitly created first, to set the intended modes, `--no-create-home` is added to mute the warning.
```
Warning: The home dir /var/lib/motion you specified already exists.
Adding system user `motion' (UID 107) ...
Adding new user `motion' (UID 107) with group `motion' ...
The home directory `/var/lib/motion' already exists.  Not copying from `/etc/skel'.
```